### PR TITLE
feat: Add YouTube video title and link to transcription files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,20 +55,23 @@ const main = async () => {
 
     // 入力がYouTubeのURLの場合、ダウンロードする
     let audioPath = inputPath;
+    let youtubeMetadata: { title: string; url: string } | undefined;
     if (isYoutubeUrl(inputPath)) {
       console.log("YouTubeのURLが検出されました。ダウンロードを開始します...");
-      const downloadedPath = await downloadFromYoutube(inputPath);
-      if (!downloadedPath) {
+      const downloadResult = await downloadFromYoutube(inputPath);
+      if (!downloadResult) {
         console.error(
           "YouTubeからのダウンロードに失敗しました。処理を中止します。"
         );
         process.exit(1);
       }
-      audioPath = downloadedPath;
+      audioPath = downloadResult.filePath;
+      youtubeMetadata = { title: downloadResult.title, url: downloadResult.url };
     }
 
     // 文字起こし処理を実行
     const config = TranscriptionConfig.fromCliOptions(options);
+    config.youtubeMetadata = youtubeMetadata;
     const exitCode = await transcribeWithScribe(audioPath, config);
 
     process.exit(exitCode);

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export class TranscriptionConfig {
   diarize: boolean;
   segmentLengthMs: number;
   showTimestamp: boolean;
+  youtubeMetadata?: { title: string; url: string };
 
   private constructor(options: TranscriptionOptions) {
     this.tagAudioEvents = options.tagAudioEvents ?? true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,20 +17,23 @@ export const transcribe = async (
   try {
     // 入力がYouTubeのURLの場合、ダウンロードする
     let audioPath = input;
+    let youtubeMetadata: { title: string; url: string } | undefined;
     if (isYoutubeUrl(input)) {
       console.log("YouTubeのURLが検出されました。ダウンロードを開始します...");
-      const downloadedPath = await downloadFromYoutube(input);
-      if (!downloadedPath) {
+      const downloadResult = await downloadFromYoutube(input);
+      if (!downloadResult) {
         console.error(
           "YouTubeからのダウンロードに失敗しました。処理を中止します。"
         );
         return 1;
       }
-      audioPath = downloadedPath;
+      audioPath = downloadResult.filePath;
+      youtubeMetadata = { title: downloadResult.title, url: downloadResult.url };
     }
 
     // 文字起こし処理を実行
     const config = TranscriptionConfig.create(options);
+    config.youtubeMetadata = youtubeMetadata;
     return await transcribeWithScribe(audioPath, config);
   } catch (error) {
     console.error(

--- a/src/transcriber.ts
+++ b/src/transcriber.ts
@@ -16,7 +16,7 @@ const writeFile = promisify(fs.writeFile);
 
 /**
  * ElevenLabsのAPIを使って一つのセグメントの文字起こしを行う
- * @param client ElevenLabsクライアント
+ * @param clientenLabsクライアント
  * @param audioFilePath 音声ファイルへのパス
  * @param config 文字起こし設定
  * @returns 文字起こし結果
@@ -109,6 +109,7 @@ export const transcribeWithScribe = async (
         outputFormat: config.outputFormat,
         numSpeakers: config.numSpeakers,
         segmentLengthMs: config.segmentLengthMs,
+        youtubeMetadata: config.youtubeMetadata,
       }),
       "utf-8"
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,15 +139,25 @@ export const createTranscriptionHeader = (
     outputFormat: string;
     numSpeakers: number;
     segmentLengthMs: number;
+    youtubeMetadata?: { title: string; url: string };
   }
 ): string => {
   const segmentLengthMinutes = Math.round(config.segmentLengthMs / 60 / 1000);
   const numSpeakersText =
     config.numSpeakers > 0 ? config.numSpeakers.toString() : "自動";
 
-  return `# 文字起こし結果
+  let header = `# 文字起こし結果
 # 元ファイル: ${path.basename(filePath)}
-# 日時: ${new Date().toISOString().replace("T", " ").slice(0, 19)}
+# 日時: ${new Date().toISOString().replace("T", " ").slice(0, 19)}`;
+
+  // YouTubeメタデータがある場合は追加
+  if (config.youtubeMetadata) {
+    header += `
+# YouTubeタイトル: ${config.youtubeMetadata.title}
+# YouTubeリンク: ${config.youtubeMetadata.url}`;
+  }
+
+  header += `
 # 設定:
 #   話者分離: ${config.diarize ? "有効" : "無効"}
 #   音声イベントタグ: ${config.tagAudioEvents ? "有効" : "無効"}
@@ -158,6 +168,8 @@ export const createTranscriptionHeader = (
 ===== 話者ごとの時系列会話 =====
 
 `;
+
+  return header;
 };
 
 /**

--- a/src/youtube-downloader.ts
+++ b/src/youtube-downloader.ts
@@ -8,12 +8,12 @@ import { sanitizeFilename } from "./utils.js";
  * YouTubeの動画をMP3形式でダウンロードする
  * @param url YouTubeのURL
  * @param outputDir 出力ディレクトリ(デフォルト: youtube_downloads)
- * @returns ダウンロードしたMP3ファイルのパス、エラー時はnull
+ * @returns ダウンロードしたMP3ファイルのパスとメタデータ、エラー時はnull
  */
 export const downloadFromYoutube = async (
   url: string,
   outputDir = path.join(process.env.PROJECT_ROOT || "", "youtube_downloads")
-): Promise<string | null> => {
+): Promise<{ filePath: string; title: string; url: string } | null> => {
   try {
     // 出力ディレクトリが存在しない場合は作成
     const absoluteOutputDir = path.resolve(outputDir);
@@ -48,7 +48,7 @@ export const downloadFromYoutube = async (
         })
         .on("end", () => {
           console.log(`ダウンロード完了: ${outputPath}`);
-          resolve(outputPath);
+          resolve({ filePath: outputPath, title: videoTitle, url });
         });
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add YouTube video title and URL to transcription file headers
- Pass YouTube metadata through the entire transcription pipeline
- Update YouTube downloader to return metadata along with file path

## Test plan
- [ ] Download and transcribe a YouTube video
- [ ] Verify the transcription file includes YouTube title and URL in the header
- [ ] Verify existing functionality still works for local audio files

🤖 Generated with [Claude Code](https://claude.ai/code)