### PR TITLE
feat: Remove audio segmentation logic

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,6 @@ export class TranscriptionConfig {
   outputDir: string;
   numSpeakers: number;
   diarize: boolean;
-  segmentLengthMs: number;
   showTimestamp: boolean;
   youtubeMetadata?: { title: string; url: string };
 
@@ -21,7 +20,6 @@ export class TranscriptionConfig {
     this.outputDir = options.outputDir ?? "transcripts";
     this.numSpeakers = options.numSpeakers ?? 0; // デフォルト値なし（0で無効化）
     this.diarize = options.diarize ?? true;
-    this.segmentLengthMs = options.segmentLengthMs ?? 4 * 60 * 60 * 1000; // 4時間
     this.showTimestamp = options.showTimestamp ?? true;
   }
 
@@ -51,7 +49,6 @@ export class TranscriptionConfig {
       outputDir: this.outputDir,
       numSpeakers: this.numSpeakers,
       diarize: this.diarize,
-      segmentLengthMs: this.segmentLengthMs,
       showTimestamp: this.showTimestamp,
     };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,6 @@ export interface TranscriptionOptions {
   outputDir?: string;
   numSpeakers?: number;
   diarize?: boolean;
-  segmentLengthMs?: number;
   showTimestamp?: boolean;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,11 +138,9 @@ export const createTranscriptionHeader = (
     tagAudioEvents: boolean;
     outputFormat: string;
     numSpeakers: number;
-    segmentLengthMs: number;
     youtubeMetadata?: { title: string; url: string };
   }
 ): string => {
-  const segmentLengthMinutes = Math.round(config.segmentLengthMs / 60 / 1000);
   const numSpeakersText =
     config.numSpeakers > 0 ? config.numSpeakers.toString() : "自動";
 
@@ -163,7 +161,6 @@ export const createTranscriptionHeader = (
 #   音声イベントタグ: ${config.tagAudioEvents ? "有効" : "無効"}
 #   出力形式: ${config.outputFormat}
 #   話者数: ${numSpeakersText}
-#   セグメント長: ${segmentLengthMinutes}分
 
 ===== 話者ごとの時系列会話 =====
 


### PR DESCRIPTION
## Summary
- Remove audio segmentation feature to simplify transcription process
- Process audio files directly without splitting into segments
- Remove the 4-hour segment length limitation

## Changes
- **transcriber.ts**: Remove `splitAudio` function calls and process audio directly
- **config.ts**: Remove `segmentLengthMs` property from configuration
- **types.ts**: Remove `segmentLengthMs` from `TranscriptionOptions` interface
- **utils.ts**: Remove segment length from transcription header

## Test plan
- [x] Build project successfully with `npm run build`
- [ ] Test transcription with short audio files
- [ ] Test transcription with long audio files (>4 hours)
- [ ] Verify output format remains consistent

🤖 Generated with [Claude Code](https://claude.ai/code)