### PR TITLE
feat: Replace dotenv with Node.js --env-file-if-exists option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@distube/ytdl-core": "^4.16.12",
         "@modelcontextprotocol/sdk": "^1.17.0",
         "commander": "^14.0.0",
-        "dotenv": "^17.2.1",
         "elevenlabs": "^1.59.0",
         "fluent-ffmpeg": "^2.1.3",
         "node-fetch": "^3.3.2",
@@ -2459,18 +2458,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js",
-    "transcribe": "node dist/cli.js",
-    "dev": "ts-node src/cli.ts",
-    "test": "jest"
+    "start": "node --env-file-if-exists=.env dist/index.js",
+    "transcribe": "node --env-file-if-exists=.env dist/cli.js",
+    "dev": "ts-node --env-file-if-exists=.env src/cli.ts",
+    "test": "jest",
+    "mcp-server": "node dist/mcp-server.js"
   },
   "keywords": [
     "elevenlabs",
@@ -35,7 +36,6 @@
     "@distube/ytdl-core": "^4.16.12",
     "@modelcontextprotocol/sdk": "^1.17.0",
     "commander": "^14.0.0",
-    "dotenv": "^17.2.1",
     "elevenlabs": "^1.59.0",
     "fluent-ffmpeg": "^2.1.3",
     "node-fetch": "^3.3.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,5 @@
-import dotenv from "dotenv";
 import { TranscriptionOptions } from "./types.js";
 import { ConfigError } from "./errors.js";
-
-dotenv.config();
 
 export class TranscriptionConfig {
   tagAudioEvents: boolean;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -3,14 +3,12 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import * as path from "path";
 import * as fs from "fs/promises";
-import dotenv from "dotenv";
 
 import { transcribe } from "./index.js";
 import { isYoutubeUrl } from "./utils.js";
 import { TranscriptionOptions } from "./types.js";
 
-// .envファイルから環境変数を読み込む
-dotenv.config();
+// Environment variables are loaded via --env-file-if-exists or MCP client config
 
 // Create server instance
 const server = new McpServer({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,11 +4,7 @@ import crypto from "crypto";
 import { promisify } from "util";
 import { SpeakerUtterance } from "./types.js";
 import ffmpeg from "fluent-ffmpeg";
-import dotenv from "dotenv";
 import { FileError } from "./errors.js";
-
-// .envファイルから環境変数を読み込む
-dotenv.config();
 
 // ファイル操作をPromise化
 const mkdir = promisify(fs.mkdir);


### PR DESCRIPTION
## Summary
- Replace dotenv library with Node.js built-in `--env-file-if-exists` option
- Fix MCP server JSON protocol interference issues
- Modernize environment variable handling using Node.js 20.6.0+ functionality

## Changes Made
- ✅ Removed dotenv dependency from package.json and all source files
- ✅ Updated npm scripts to use `--env-file-if-exists=.env` option
- ✅ Fixed MCP server startup issues caused by dotenv debug output
- ✅ Added `mcp-server` script to package.json for consistency
- ✅ Reduced package size by eliminating external dependency

## Benefits
- **No external dependencies**: Uses Node.js built-in functionality
- **Environment flexibility**: Works with or without .env file
- **MCP compatibility**: No JSON protocol interference
- **Smaller bundle**: Reduced package size
- **Modern approach**: Leverages Node.js 20.6.0+ features

## Testing
- [x] CLI functionality with .env file
- [x] CLI functionality without .env file  
- [x] MCP server startup without errors
- [x] Environment variable loading in both modes

## Test plan
- [ ] Verify CLI transcription works with API key from .env
- [ ] Verify MCP server works with Claude Desktop
- [ ] Test deployment without .env file (production scenario)

🤖 Generated with [Claude Code](https://claude.ai/code)