### PR TITLE
feat: Include seconds in timestamp to prevent filename duplicates

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export const generateOutputFilename = async (
     .toISOString()
     .replace(/[:.]/g, "")
     .replace("T", "_")
-    .slice(0, 15);
+    .slice(0, 19);
   return path.join(absoluteOutputDir, `transcript_${timestamp}.txt`);
 };
 
@@ -198,7 +198,7 @@ export async function splitAudio(
     .toISOString()
     .replace(/[:.]/g, "")
     .replace("T", "_")
-    .slice(0, 15);
+    .slice(0, 19);
 
   // 出力用の一時ディレクトリを作成（タイムスタンプ付きで絶対パスで指定）
   const workspacePath = process.env.PROJECT_ROOT || "";


### PR DESCRIPTION
## Summary
- タイムスタンプの文字数を15文字から19文字に変更し、秒数を含むように修正
- ファイル名の形式が `YYYYMMDD_HHMM` から `YYYYMMDD_HHMMSS` になり、同じ分内での重複を防止

## Test plan
- [ ] 短時間で複数回文字起こしを実行してファイル名が重複しないことを確認
- [ ] タイムスタンプの形式が正しく生成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)